### PR TITLE
Fixed: Height of the cards

### DIFF
--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -31,7 +31,7 @@ export default function Services() {
           <Link key={service.title} href={`/services/${service.slug}`}>
             <Card
               key={service.title}
-              className="group relative overflow-hidden"
+              className="group relative overflow-hidden h-[300px]"
             >
               <CardHeader>
                 <div className="mb-4 inline-block rounded-lg bg-primary/10 p-3">
@@ -46,7 +46,7 @@ export default function Services() {
                 <CardTitle>{service.title}</CardTitle>
                 <CardDescription>{service.description}</CardDescription>
               </CardHeader>
-              <CardContent>
+              <CardContent className="absolute bottom-0">
                 <ul className="grid gap-2">
                   {service.features.map((feature) => (
                     <li key={feature} className="flex items-center gap-2">


### PR DESCRIPTION
## What does this PR do ?
This PR is basically fixing the height of all the cards in our Service section for better Visualization 

## Before this PR, Our Service Section 
![Before](https://github.com/user-attachments/assets/2379ad3c-86b7-48d5-b9e6-b845f0405c41)


## After this PR, Our service Section will be look like
![After](https://github.com/user-attachments/assets/9657ec87-e64b-495d-9aa6-4f130cf3f09f)

Fixes #2  